### PR TITLE
Fix GitHub link in PDF footer

### DIFF
--- a/scripts/generatePDF.py
+++ b/scripts/generatePDF.py
@@ -322,7 +322,7 @@ if __name__ == "__main__":
         75,
         10,
         8,
-        "This PDF only works in Chromium-based browsers. Visit https://github.com/EvanZhouDev/llm-pdf for more information.",
+        "This PDF only works in Chromium-based browsers. Visit https://github.com/EvanZhouDev/llm.pdf for more information.",
     )
 
     page.AA = PdfDict()


### PR DESCRIPTION
The disclaimer about Chromium-based browsers includes a broken link (`https://github.com/EvanZhouDev/llm-pdf`). I updated it to the actual GitHub link.

P.S. Cloning this repository was difficult due to the `builds` folder. It would be better to move the artifacts to the releases page at https://github.com/EvanZhouDev/llm.pdf/releases.